### PR TITLE
Fix charging status enum translation

### DIFF
--- a/batteryComponentYellow/battery.c
+++ b/batteryComponentYellow/battery.c
@@ -524,6 +524,12 @@ static ma_battery_ChargingStatus_t ReadChargingStatus
         {
             return MA_BATTERY_FULL;
         }
+        else if (strcmp(chargingStatus, "Not charging") == 0)
+        {
+            // In this case, something is wrong that is preventing the battery from charging.
+            // E.g., the thermistor is reporting that the battery is too hot or too cold.
+            return MA_BATTERY_CHARGEERROR;
+        }
         else
         {
             LE_ERROR("Unrecognized charging status '%s'.", chargingStatus);
@@ -535,7 +541,7 @@ static ma_battery_ChargingStatus_t ReadChargingStatus
     {
         LE_ERROR("failed to read the charging status (%s).", LE_RESULT_TXT(r));
 
-        return MA_BATTERY_CHARGEERROR;
+        return MA_BATTERY_HEALTHUNDEFINED;
     }
 }
 

--- a/batteryComponentYellow/battery.c
+++ b/batteryComponentYellow/battery.c
@@ -110,9 +110,9 @@ static const char* GetHealthStr
         case MA_BATTERY_GOOD:               return "good";
         case MA_BATTERY_COLD:               return "cold";
         case MA_BATTERY_HOT:                return "hot";
-        case MA_BATTERY_HEALTHUNDEFINED:    return "undefined";
-        case MA_BATTERY_HEALTHERROR:        return "error";
         case MA_BATTERY_DISCONNECTED:       return "disconnected";
+        case MA_BATTERY_HEALTH_UNKNOWN:     return "unknown";
+        case MA_BATTERY_HEALTH_ERROR:       return "error";
     }
 
     LE_CRIT("Unexpected health code %d.", healthCode);
@@ -319,7 +319,7 @@ static void ReportChargingStatusChange
     ma_battery_ChargingStatus_t status
 )
 {
-    static ma_battery_ChargingStatus_t oldStatus = MA_BATTERY_CHARGEUNDEFINED;
+    static ma_battery_ChargingStatus_t oldStatus = MA_BATTERY_CHARGING_UNKNOWN;
 
     if (oldStatus != status)
     {
@@ -409,7 +409,7 @@ static void ReportHealthStatusChange
     ma_battery_HealthStatus_t healthStatus
 )
 {
-    static ma_battery_HealthStatus_t oldStatus = MA_BATTERY_HEALTHUNDEFINED;
+    static ma_battery_HealthStatus_t oldStatus = MA_BATTERY_HEALTH_UNKNOWN;
 
     if (oldStatus != healthStatus)
     {
@@ -526,22 +526,24 @@ static ma_battery_ChargingStatus_t ReadChargingStatus
         }
         else if (strcmp(chargingStatus, "Not charging") == 0)
         {
-            // In this case, something is wrong that is preventing the battery from charging.
-            // E.g., the thermistor is reporting that the battery is too hot or too cold.
-            return MA_BATTERY_CHARGEERROR;
+            return MA_BATTERY_NOT_CHARGING;
+        }
+        else if (strcmp(chargingStatus, "Unknown") == 0)
+        {
+            return MA_BATTERY_CHARGING_UNKNOWN;
         }
         else
         {
             LE_ERROR("Unrecognized charging status '%s'.", chargingStatus);
 
-            return MA_BATTERY_HEALTHUNDEFINED;
+            return MA_BATTERY_CHARGING_ERROR;
         }
     }
     else
     {
         LE_ERROR("failed to read the charging status (%s).", LE_RESULT_TXT(r));
 
-        return MA_BATTERY_HEALTHUNDEFINED;
+        return MA_BATTERY_CHARGING_ERROR;
     }
 }
 
@@ -616,12 +618,12 @@ static ma_battery_HealthStatus_t ReadHealthStatus
         else
         {
             LE_ERROR("Unrecognized health string from driver: '%s'.", healthValue);
-            return MA_BATTERY_HEALTHUNDEFINED;
+            return MA_BATTERY_HEALTH_ERROR;
         }
     }
     else
     {
-        return MA_BATTERY_HEALTHERROR;
+        return MA_BATTERY_HEALTH_ERROR;
     }
 }
 
@@ -654,7 +656,7 @@ ma_battery_ChargingStatus_t ma_battery_GetChargingStatus
     void
 )
 {
-    ma_battery_ChargingStatus_t status = MA_BATTERY_CHARGEUNDEFINED;
+    ma_battery_ChargingStatus_t status = MA_BATTERY_CHARGING_UNKNOWN;
 
     if (BatteryPresent())
     {
@@ -926,7 +928,7 @@ static void PushToDataHub
 //--------------------------------------------------------------------------------------------------
 {
     ma_battery_HealthStatus_t healthStatus = MA_BATTERY_DISCONNECTED;
-    ma_battery_ChargingStatus_t chargingStatus = MA_BATTERY_CHARGEUNDEFINED;
+    ma_battery_ChargingStatus_t chargingStatus = MA_BATTERY_CHARGING_UNKNOWN;
     bool isCharging = false;
     uint charge = 0;
     uint percentage = 0;
@@ -1002,7 +1004,7 @@ static void AlarmCheckTimerExpiryHandler
 )
 {
     ma_battery_HealthStatus_t healthStatus = MA_BATTERY_DISCONNECTED;
-    ma_battery_ChargingStatus_t chargingStatus = MA_BATTERY_CHARGEUNDEFINED;
+    ma_battery_ChargingStatus_t chargingStatus = MA_BATTERY_CHARGING_UNKNOWN;
     uint percentage = 0;
 
     if (BatteryPresent())

--- a/ma_battery.api
+++ b/ma_battery.api
@@ -81,9 +81,10 @@ ENUM ChargingStatus
                    ///< there is a charge fault.  It could also be discharging when in
                    ///< "supplement mode" but there is no way to tell when it's in that mode.
     CHARGING,      ///< Battery is being charged
+    NOT_CHARGING,  ///< Battery is not being charged or discharged
     FULL,          ///< Battery is fully charged
-    CHARGEUNDEFINED,     ///< Battery condition is not defined
-    CHARGEERROR,         ///< Error
+    CHARGING_UNKNOWN, ///< Battery charging status is not known
+    CHARGING_ERROR,   ///< Error in getting the charging status
 };
 
 
@@ -100,9 +101,9 @@ ENUM HealthStatus
     GOOD,            ///< Battery is in good health
     COLD,            ///< Battery is cold and cannot charge. Check datasheet
     HOT,             ///< Battery is hot and cannot charge.  Check datasheet
-    HEALTHUNDEFINED, ///< Battery health not defined
-    HEALTHERROR,     ///< Error in getting health
     DISCONNECTED,    ///< Battery is not connected.
+    HEALTH_UNKNOWN,  ///< Battery health is not known
+    HEALTH_ERROR,    ///< Error in getting health
 };
 
 


### PR DESCRIPTION
Handle the previously unhandled 'Not charging' status from the driver.
This is an error condition that should translate to 'CHARGEERROR',
meaning that there is an error condition preventing charging.

Translate failure to read the charging status into 'HEALTHUNDEFINED'
instead of 'CHARGEERROR' because being unable to read the status
does not necessarily mean that charging isn't working.